### PR TITLE
add route to detail on ORGANIC, webinar logic

### DIFF
--- a/server/custom/attribution-logic.js
+++ b/server/custom/attribution-logic.js
@@ -37,21 +37,26 @@ function createTraitsFromEvent(eventData: any, prefix: string = ""): any {
   }
 
   if (eventData.event === "Signed Up") {
-    const route = _.get(eventData, "properties.route", "n/a");
-    if (route === "https://app.drift.com/white-glove/") {
+    const route = _.get(eventData, "properties.route") ? _.get(eventData, "properties.route").split("?")[0] : "ORGANIC";
+    if (route.indexOf("app.drift.com/white-glove") !== -1) {
       _.set(traits, `${prefix}lead_source`, "Other");
       _.set(traits, `${prefix}lead_source_detail`, "Deal Link");
     } else {
       _.set(traits, `${prefix}lead_source`, "PQL");
-      if (route === "https://www.drift.com/sales/") {
+      if (_.get(eventData, "properties.type") === "INVITE") {
+        _.set(traits, `${prefix}lead_source_detail`, "INVITE");
+      } else if (route.indexOf("drift.com/sales") !== -1) {
         _.set(traits, `${prefix}lead_source_detail`, "Drift.com/sales");
       } else {
-        _.set(traits, `${prefix}lead_source_detail`, _.get(eventData, "properties.type", "ORGANIC"));
+        _.set(traits, `${prefix}lead_source_detail`, route);
       }
     }
   } else if (eventData.event === "Email Captured") {
     const pageUrl = _.get(eventData, "context.page_url", "").split("?")[0];
-    if (pageUrl.indexOf("blog.drift.com") !== -1) {
+    if (pageUrl.indexOf("drift.com/webinars") !== -1) {
+      _.set(traits, `${prefix}lead_source`, "Webinar");
+      _.set(traits, `${prefix}lead_source_detail`, pageUrl);
+    } else if (pageUrl.indexOf("blog.drift.com") !== -1) {
       _.set(traits, `${prefix}lead_source`, "MQL");
       _.set(traits, `${prefix}lead_source_detail`, pageUrl);
     } else if (pageUrl.indexOf("drift.com/startups") !== -1) {

--- a/test/integration/fixtures/expectations/user-noaccount-scenario05.js
+++ b/test/integration/fixtures/expectations/user-noaccount-scenario05.js
@@ -2,7 +2,7 @@
 module.exports = (ctxMock) => {
   const expectedTraits = {
     lead_source: "PQL",
-    lead_source_detail: "ORGANIC",
+    lead_source_detail: "https://www.drift.com/pricing/",
     lead_source_timestamp: "2018-02-20T20:52:24Z",
     last_lead_source: "PQL",
     last_lead_source_detail: "ORGANIC",

--- a/test/unit/attribution-logic.spec.js
+++ b/test/unit/attribution-logic.spec.js
@@ -56,6 +56,63 @@ describe("createTraitsFromEvent", () => {
     expect(traits).toEqual(expected);
   });
 
+  test("should create attributes for event 'Signed Up' route initial", () => {
+    const eventData = {
+      id: "abkbiuegwlh",
+      indexed_at: "2018-02-10T09:43:57+00:00",
+      created_at: "2018-02-10T09:38:48+00:00",
+      event: "Signed Up",
+      source: "segment",
+      context: {
+        days_since_signup: 0
+      },
+      properties: {
+        email: "somebody12345@hull.io",
+        type: "ORGANIC",
+        route: "drift.com/pricing"
+      }
+    };
+
+    const expected = {
+      lead_source: "PQL",
+      lead_source_detail: "drift.com/pricing",
+      lead_source_timestamp: "2018-02-10T09:38:48+00:00"
+    };
+
+    const traits = createTraitsFromEvent(eventData);
+
+    expect(traits).toEqual(expected);
+  });
+
+  test("should create attributes for event 'Signed Up' route last", () => {
+    const eventData = {
+      id: "abkbiuegwlh",
+      indexed_at: "2018-02-10T09:43:57+00:00",
+      created_at: "2018-02-10T09:38:48+00:00",
+      event: "Signed Up",
+      source: "segment",
+      context: {
+        days_since_signup: 0
+      },
+      properties: {
+        email: "somebody12345@hull.io",
+        type: "ORGANIC",
+        route: "drift.com/pricing"
+      }
+    };
+
+    const expected = {
+      last_lead_source: "PQL",
+      last_lead_source_detail: "drift.com/pricing",
+      last_lead_source_timestamp: "2018-02-10T09:38:48+00:00"
+    };
+
+    const traits = createTraitsFromEvent(eventData, "last_");
+
+    expect(traits).toEqual(expected);
+  });
+
+
   test("should create attributes for event 'Signed Up' deal link initial", () => {
     const eventData = {
       id: "abkbiuegwlh",
@@ -104,6 +161,60 @@ describe("createTraitsFromEvent", () => {
     const expected = {
       last_lead_source: "Other",
       last_lead_source_detail: "Deal Link",
+      last_lead_source_timestamp: "2018-02-10T09:38:48+00:00"
+    };
+
+    const traits = createTraitsFromEvent(eventData, "last_");
+
+    expect(traits).toEqual(expected);
+  });
+
+  test("should create attributes for event 'Signed Up' invite initial", () => {
+    const eventData = {
+      id: "abkbiuegwlh",
+      indexed_at: "2018-02-10T09:43:57+00:00",
+      created_at: "2018-02-10T09:38:48+00:00",
+      event: "Signed Up",
+      source: "segment",
+      context: {
+        days_since_signup: 0
+      },
+      properties: {
+        email: "somebody12345@hull.io",
+        type: "INVITE",
+      }
+    };
+
+    const expected = {
+      lead_source: "PQL",
+      lead_source_detail: "INVITE",
+      lead_source_timestamp: "2018-02-10T09:38:48+00:00"
+    };
+
+    const traits = createTraitsFromEvent(eventData);
+
+    expect(traits).toEqual(expected);
+  });
+
+  test("should create attributes for event 'Signed Up' invite last", () => {
+    const eventData = {
+      id: "abkbiuegwlh",
+      indexed_at: "2018-02-10T09:43:57+00:00",
+      created_at: "2018-02-10T09:38:48+00:00",
+      event: "Signed Up",
+      source: "segment",
+      context: {
+        days_since_signup: 0
+      },
+      properties: {
+        email: "somebody12345@hull.io",
+        type: "INVITE",
+      }
+    };
+
+    const expected = {
+      last_lead_source: "PQL",
+      last_lead_source_detail: "INVITE",
       last_lead_source_timestamp: "2018-02-10T09:38:48+00:00"
     };
 


### PR DESCRIPTION
- If the page_url is from the webinar page, then it is a CQL with detail `Webinar`
- If the signup is an INVITE, then say INVITE as the detail. Otherwise, if route exists show the route. Else say ORGANIC.